### PR TITLE
model: use cascade for the foreign key on workflows

### DIFF
--- a/inspire_crawler/models.py
+++ b/inspire_crawler/models.py
@@ -114,9 +114,15 @@ class CrawlerWorkflowObject(db.Model):
     __tablename__ = "crawler_workflows_object"
 
     job_id = db.Column(UUIDType, primary_key=True)
-    object_id = db.Column(db.Integer,
-                          db.ForeignKey(WorkflowObjectModel.id),
-                          primary_key=True)
+    object_id = db.Column(
+        db.Integer,
+        db.ForeignKey(
+            WorkflowObjectModel.id,
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+        ),
+        primary_key=True
+    )
 
 
 __all__ = (


### PR DESCRIPTION
* That allows removing the workflow without having to know the
  internal structure of the model.

Signed-off-by: David Caro <david@dcaro.es>