### PR TITLE
tasks.submit_results: improve memory usage

### DIFF
--- a/inspire_crawler/tasks.py
+++ b/inspire_crawler/tasks.py
@@ -75,10 +75,10 @@ def submit_results(job_id, errors, log_file, results_uri, results_data=None):
         )
         results_data = []
         with open(results_path) as records:
-            lines = [
-                line.strip() for line in records.readlines()
-                if line.strip()
-            ]
+            lines = (
+                line.strip() for line in records if line.strip()
+            )
+
             for line in lines:
                 current_app.logger.debug(
                     'Reading record line: {}'.format(line)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -69,11 +69,12 @@ def sample_records_uri(sample_records_filename):
 @pytest.fixture()
 def sample_records(sample_records_filename):
     with open(sample_records_filename) as records_fd:
-        records = [
+        records = (
             json.loads(line.strip()) for line in records_fd.readlines()
-        ]
+            if line.strip()
+        )
 
-    return records
+    return list(records)
 
 
 @pytest.fixture()


### PR DESCRIPTION
By using generators instead of fully loading files to memory.

Signed-off-by: David Caro <david@dcaro.es>