### PR TITLE
submit_results: use a dedicated celery queue

### DIFF
--- a/inspire_crawler/config.py
+++ b/inspire_crawler/config.py
@@ -61,3 +61,9 @@ You can also pass arguments directly to the scheduler with kwargs.
 """
 
 CRAWLER_OAIHARVEST_OUTPUT_DIRECTORY = "crawls"
+
+
+CRAWLER_CELERY_QUEUE = "harvests"
+"""Name of the celery queue to use for harvests, if set to 'None' will not use
+any specific name.
+"""


### PR DESCRIPTION
Adds the CRAWLER_CELERY_QUEUE conf variable to configure it.

Signed-off-by: David Caro <david@dcaro.es>